### PR TITLE
Making pipe control easy

### DIFF
--- a/src/Interfaces/RedisInterface.php
+++ b/src/Interfaces/RedisInterface.php
@@ -16,4 +16,7 @@ interface RedisInterface extends
 				SortedSetMethodsInterface,
 				StringMethodsInterface,
 				TransactionMethodsInterface {
+
+	public function beginPipe();
+	public function executePipe();
 }


### PR DESCRIPTION
This adds two functions to RedisProtocol (and RedisInterface). If you want them off the Interface that makes sense too, but since we'll be passing Interfaces around in our myon code and RedisInterface is only implemented in classes that extend RedisProtocol I figured the methods could go on the interface as well to make our lives easier.

beginPipe() signals to the protocol object that all exe() calls should be piped. It captures each call and holds it in an array instead of executing it. 
executePipe() then executes the stored array and brings things back to normal.

It's adding another layer of depth so I'm sure it's violating some sort of coding practice but it makes piping with only the Redis object pretty simple: 

```
		$this->getConnection()->beginPiping();
		$this->getConnection()->zincrby($this->makeKey(RedisKeys::USERPAGE_TOTAL_PAGES, $userId), 1, $daysSince);
		$this->getConnection()->zincrby($this->makeKey(RedisKeys::USERPAGE_TOTAL_TIME, $userId), $time, $daysSince);
		$this->getConnection()->zincrby($this->makeKey(RedisKeys::USERPAGE_AVG_LEXILE_SUM, $userId), $lexile, $daysSince);
		$this->getConnection()->executePipe();

```

Thoughts?