### PR TITLE
Close the socket on __destruct()

### DIFF
--- a/src/RedisProtocol.php
+++ b/src/RedisProtocol.php
@@ -234,6 +234,15 @@ class RedisProtocol {
 
 	}
 
+	/**
+	 * Close the socket when we fall out of scope.
+	 */
+	function __destruct() {
+		if(is_resource($this->handle)) {
+			@fclose($this->handle);
+		}
+	}
+
 }
 
 


### PR DESCRIPTION
This closes the socket when Redis falls out of scope/the end of the script which helps ephemeral ports recycle faster.