### PR TITLE
Change pipe() to take an array argument rather than using magic

### DIFF
--- a/src/Interfaces/RedisInterface.php
+++ b/src/Interfaces/RedisInterface.php
@@ -29,5 +29,5 @@ interface RedisInterface extends
 	const KILL_TYPE_SLAVE  = "slave";
 	const KILL_TYPE_PUBSUB = "pubsub";
 
-	public function pipe();
+	public function pipe( array $args );
 }

--- a/src/RedisProtocol.php
+++ b/src/RedisProtocol.php
@@ -76,11 +76,11 @@ class RedisProtocol {
 	 * to Redis. Since Protocol::protocol takes strings and arrays and
 	 * assumes that they're all one specific command, this funciton takes
 	 * an array of those.
+	 *
+	 * @param array $args
 	 * @return mixed
 	 */
-	public function pipe(){
-		$args = func_get_args();
-
+	public function pipe( array $args ){
 		if( count($args) == 1 ){
 			$args = reset($args);
 		}


### PR DESCRIPTION
This gives us much better static analysis. Functionally the same so long as we're not passing in an array as multiple arguments (why would we be doing that?) like pipe([],[],[],[],[]).
